### PR TITLE
Add configurable admin notifications for new user registrations

### DIFF
--- a/.env.dev.template
+++ b/.env.dev.template
@@ -31,6 +31,11 @@ TOKEN=
 # Example: 123456789
 ADMIN_ID_LIST=
 
+# Enable notifications to admins when new users register
+# Development: true (useful for monitoring test users)
+# Options: true | false
+NOTIFY_ADMINS_NEW_USER=true
+
 # Support contact link shown to users (Telegram username or group)
 # Example: https://t.me/your_username
 SUPPORT_LINK=

--- a/.env.prod.template
+++ b/.env.prod.template
@@ -41,6 +41,11 @@ TOKEN=
 # - Limit admin access to essential personnel only
 ADMIN_ID_LIST=
 
+# Enable notifications to admins when new users register
+# Production: true (monitor new user registrations)
+# Options: true | false
+NOTIFY_ADMINS_NEW_USER=true
+
 # Support contact link shown to users (Telegram username or group)
 # Example: https://t.me/your_support_bot
 SUPPORT_LINK=

--- a/config.py
+++ b/config.py
@@ -121,6 +121,9 @@ ADMIN_ID_HASHES = [generate_admin_id_hash(admin_id) for admin_id in ADMIN_ID_LIS
 # - Never commit .env to version control
 # - Rotate admin IDs if env file is compromised
 
+# Admin Notifications
+NOTIFY_ADMINS_NEW_USER = os.environ.get("NOTIFY_ADMINS_NEW_USER", "true") == "true"  # Default: enabled
+
 SUPPORT_LINK = os.environ.get("SUPPORT_LINK")
 DB_ENCRYPTION = os.environ.get("DB_ENCRYPTION", False) == 'true'
 DB_NAME = os.environ.get("DB_NAME")

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -91,6 +91,8 @@
     "notification_new_deposit": "Guthaben wurde erfolgreich um {fiat_amount:.2f} {currency_text} aufgeladen.\nReferenz: {payment_id}",
     "notification_new_deposit_id": "💰 Neue Einzahlung von Benutzer mit ID {telegram_id} in Höhe von {currency_sym}{deposit_amount_usd} mit ",
     "notification_new_deposit_username": "💰 Neue Einzahlung von Benutzer mit Benutzername @{username} in Höhe von {currency_sym}{deposit_amount_usd} mit ",
+    "notification_new_user_registration_username": "👤 Neue Benutzerregistrierung: @{username} (ID: {telegram_id})",
+    "notification_new_user_registration_id": "👤 Neue Benutzerregistrierung: ID {telegram_id}",
     "notification_purchase_with_tgid": "🛒 Ein neuer Kauf von Benutzer @{username} in Höhe von {currency_sym}{total_price} für den Kauf von {quantity} Stk. {category_name} {subcategory_name}.",
     "notification_purchase_with_username": "🛒 Ein neuer Kauf von Benutzer mit ID:{telegram_id} in Höhe von {currency_sym}{total_price} für den Kauf von {quantity} Stk. {category_name} {subcategory_name}.",
     "notification_seed": "🔑 Seed: <code>{seed}</code>",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -90,6 +90,8 @@
     "new_users_msg": "👥 <b>{users_count} new users in the last {timedelta} days:</b>",
     "notification_new_deposit_id": "💰 New deposit by user with ID {telegram_id} for {currency_sym}{deposit_amount_fiat:.2f} with 💰 {value} {crypto_name}",
     "notification_new_deposit_username": "💰 New deposit by user with username @{username} for {currency_sym}{deposit_amount_fiat:.2f} with 💰 {value} {crypto_name}",
+    "notification_new_user_registration_username": "👤 New user registration: @{username} (ID: {telegram_id})",
+    "notification_new_user_registration_id": "👤 New user registration: ID {telegram_id}",
     "notification_purchase_with_tgid": "🛒 A new purchase by user @{username} for the amount of {currency_sym}{total_price:.2f} for the purchase of a {quantity} pcs {category_name} {subcategory_name}.",
     "notification_purchase_with_username": "🛒 A new purchase by user with ID:{telegram_id} for the amount of {currency_sym}{total_price:.2f} for the purchase of a {quantity} pcs {category_name} {subcategory_name}.",
     "notification_seed": "🔑 Seed: <code>{seed}</code>",

--- a/services/notification.py
+++ b/services/notification.py
@@ -126,6 +126,28 @@ class NotificationService:
         await NotificationService.send_to_admins(message, user_button)
 
     @staticmethod
+    async def notify_new_user_registration(user_dto: UserDTO):
+        """
+        Notifies admins when a new user registers.
+
+        Handles both users with and without username.
+        Configurable via NOTIFY_ADMINS_NEW_USER env var.
+        """
+        user_button = await NotificationService.make_user_button(user_dto.telegram_username)
+
+        if user_dto.telegram_username:
+            message = Localizator.get_text(BotEntity.ADMIN, "notification_new_user_registration_username").format(
+                username=safe_html(user_dto.telegram_username),
+                telegram_id=user_dto.telegram_id
+            )
+        else:
+            message = Localizator.get_text(BotEntity.ADMIN, "notification_new_user_registration_id").format(
+                telegram_id=user_dto.telegram_id
+            )
+
+        await NotificationService.send_to_admins(message, user_button)
+
+    @staticmethod
     async def new_buy(sold_items: list[CartItemDTO], user: UserDTO, session: AsyncSession | Session):
         user_button = await NotificationService.make_user_button(user.telegram_username)
         cart_grand_total = 0.0

--- a/services/user.py
+++ b/services/user.py
@@ -29,6 +29,11 @@ class UserService:
                 user_id = await UserRepository.create(user_dto, session)
                 await CartRepository.get_or_create(user_id, session)
                 await session_commit(session)
+
+                # Notify admins about new user registration (if enabled)
+                if config.NOTIFY_ADMINS_NEW_USER:
+                    from services.notification import NotificationService
+                    await NotificationService.notify_new_user_registration(user_dto)
             case _:
                 update_user_dto = UserDTO(**user.model_dump())
                 update_user_dto.can_receive_messages = True


### PR DESCRIPTION
## Problem
Admins were not notified when new users registered, especially when users had no Telegram username (only ID). This made it difficult to monitor new user activity and detect potential issues.

## Solution
Implemented configurable admin notification system that alerts admins whenever a new user is created, regardless of entry point (start command, direct shop access, etc.).

## Changes
- **Configuration**: Added `NOTIFY_ADMINS_NEW_USER` environment variable (default: `true`)
- **NotificationService**: New method `notify_new_user_registration()` with support for:
  - Users with username: Shows `@username (ID: 123456789)` with profile button
  - Users without username: Shows `ID 123456789` without button (profile link not possible)
- **UserService**: Integrated notification into `create_if_not_exist()` (only triggers on first user creation)
- **Localization**: Added German and English notification strings
- **Security**: Uses `safe_html()` for XSS protection on usernames
- **Documentation**: Updated `.env.dev.template` and `.env.prod.template`

## Behavior
- Notification triggers **once** on first user contact with bot
- Works across all entry points (start command, filters, handlers)
- Configurable via `.env` - can be disabled if not needed

## Configuration
```bash
# Enable/disable admin notifications for new users (default: true)
NOTIFY_ADMINS_NEW_USER=true
```

## Testing
Tested notification delivery for:
- [x] Users with username
- [x] Users without username (ID only)
- [x] Config parameter enable/disable
- [x] HTML escaping for security