### PR TITLE
fix: include unit field in order item grouping

### DIFF
--- a/services/order.py
+++ b/services/order.py
@@ -2234,35 +2234,38 @@ class OrderService:
     @staticmethod
     def _group_items_for_display(items: list[dict]) -> list[dict]:
         """
-        Group items for display based on (name, price, is_physical, private_data).
+        Group items for display based on (name, price, is_physical, private_data, unit).
 
         Items with identical attributes (including private_data) are grouped together.
         Items with unique private_data remain separate.
 
         Args:
-            items: List of item dicts with keys: name, price, quantity, is_physical, private_data, tier_breakdown (optional)
+            items: List of item dicts with keys: name, price, quantity, is_physical, private_data, tier_breakdown (optional), unit (optional)
 
         Returns:
             List of grouped items with updated quantities
         """
         grouped = {}
         tier_breakdown_map = {}  # Store tier_breakdown for each group
+        unit_map = {}  # Store unit for each group
 
         for item in items:
-            # Group by all attributes including private_data
+            # Group by all attributes including private_data and unit
             # This ensures items with identical private_data get grouped,
             # but items with unique private_data (keys, codes) stay separate
             key = (
                 item['name'],
                 item['price'],
                 item['is_physical'],
-                item.get('private_data')  # None or actual value
+                item.get('private_data'),  # None or actual value
+                item.get('unit')  # Include unit in grouping key
             )
 
             if key not in grouped:
                 grouped[key] = 0
-                # Store tier_breakdown for first item in group
+                # Store tier_breakdown and unit for first item in group
                 tier_breakdown_map[key] = item.get('tier_breakdown')
+                unit_map[key] = item.get('unit')
             grouped[key] += item.get('quantity', 1)
 
         # Build result list
@@ -2273,9 +2276,10 @@ class OrderService:
                 'quantity': quantity,
                 'is_physical': is_physical,
                 'private_data': private_data,
-                'tier_breakdown': tier_breakdown_map.get((name, price, is_physical, private_data))
+                'tier_breakdown': tier_breakdown_map.get((name, price, is_physical, private_data, unit)),
+                'unit': unit  # Include unit in result
             }
-            for (name, price, is_physical, private_data), quantity in grouped.items()
+            for (name, price, is_physical, private_data, unit), quantity in grouped.items()
         ]
 
     @staticmethod

--- a/services/order.py
+++ b/services/order.py
@@ -2277,7 +2277,7 @@ class OrderService:
                 'is_physical': is_physical,
                 'private_data': private_data,
                 'tier_breakdown': tier_breakdown_map.get((name, price, is_physical, private_data, unit)),
-                'unit': unit  # Include unit in result
+                'unit': unit if unit is not None else 'pcs.'  # Default to pcs. if unit is None
             }
             for (name, price, is_physical, private_data, unit), quantity in grouped.items()
         ]


### PR DESCRIPTION
Order items were displayed as repeated "1 pcs." entries instead of grouped quantities because _group_items_for_display() did not include the unit field in the grouping key and result dictionary. Added unit to both grouping key and result to fix the display.