### PR TITLE
fix: default unit to 'pcs.' when None

### DIFF
--- a/services/order.py
+++ b/services/order.py
@@ -2277,7 +2277,7 @@ class OrderService:
                 'is_physical': is_physical,
                 'private_data': private_data,
                 'tier_breakdown': tier_breakdown_map.get((name, price, is_physical, private_data, unit)),
-                'unit': unit  # Include unit in result
+                'unit': unit if unit is not None else 'pcs.'  # Default to pcs. if unit is None
             }
             for (name, price, is_physical, private_data, unit), quantity in grouped.items()
         ]


### PR DESCRIPTION
Prevents displaying 'None' in purchase history when items lack an explicit unit field. Callers like BuyService.get_purchase build items_raw without units, causing _group_items_for_display to return unit=None, which was passed directly to Localizator.localize_unit. This rendered purchase lines like '3 None Item...' instead of '3 pcs. Item...'

**Fix:** In services/order.py:2280, default unit to 'pcs.' when None.