### PR TITLE
refactor: add type-safe invoice header enum and fix datetime deprecations

### DIFF
--- a/TODO/2025-11-29_TODO_telegram-timestamp-formatting.md
+++ b/TODO/2025-11-29_TODO_telegram-timestamp-formatting.md
@@ -1,0 +1,56 @@
+# TODO: Implement Telegram Timestamp Formatting
+
+## Problem
+Currently, datetime values in Telegram messages are sent as pre-formatted strings (e.g., `"2025-11-29 12:00"`). This means all users see the same time regardless of their timezone, typically UTC or server time.
+
+## Solution
+Use Telegram's built-in timestamp formatting feature that automatically converts Unix timestamps to each user's local timezone.
+
+### Current Implementation
+```python
+date = datetime.now().strftime("%Y-%m-%d %H:%M")  # → "2025-11-29 12:00"
+message = f"Created: {date}"
+```
+
+### Proposed Implementation
+```python
+timestamp = int(datetime.now(timezone.utc).timestamp())
+message = f"Created: <t:{timestamp}:f>"  # Telegram auto-converts to user's TZ
+```
+
+## Telegram Timestamp Formats
+- `<t:TIMESTAMP:t>` - Short time (e.g., "16:20")
+- `<t:TIMESTAMP:T>` - Long time (e.g., "16:20:30")
+- `<t:TIMESTAMP:d>` - Short date (e.g., "20/04/2021")
+- `<t:TIMESTAMP:D>` - Long date (e.g., "20 April 2021")
+- `<t:TIMESTAMP:f>` - Short date/time (e.g., "20 April 2021 16:20")
+- `<t:TIMESTAMP:F>` - Long date/time (e.g., "Tuesday, 20 April 2021 16:20")
+- `<t:TIMESTAMP:R>` - Relative time (e.g., "2 hours ago")
+
+## Benefits
+- Automatic timezone conversion for each user
+- No server-side timezone configuration needed
+- Consistent user experience across different regions
+- Native Telegram feature (no external dependencies)
+
+## Implementation Steps
+1. Create utility function `format_datetime_for_telegram(dt: datetime, style: str = 'f') -> str`
+2. Update `invoice_formatter.py` to use Telegram timestamps instead of `.strftime()`
+3. Update all other locations using datetime formatting in messages:
+   - Order notifications
+   - Payment confirmations
+   - Shipping notifications
+   - Cancellation messages
+4. Test with users in different timezones
+5. Update documentation
+
+## Files to Modify
+- `services/invoice_formatter.py` - Multiple `.strftime()` calls
+- `services/notification.py` - Notification timestamps
+- `utils/` - New utility function for Telegram timestamp formatting
+
+## Priority
+Medium - Improves UX for international users but not critical for functionality
+
+## Estimated Effort
+2-3 hours (implement utility, update formatters, test)

--- a/enums/invoice_header_type.py
+++ b/enums/invoice_header_type.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+
+class InvoiceHeaderType(Enum):
+    """
+    Invoice header types for format_complete_order_view().
+
+    Defines the type of invoice header to display, which determines:
+    - Header text/emoji
+    - Which sections to show (payment, refund, cancellation)
+    - Field labels and formatting
+    """
+
+    # Admin Views
+    ADMIN_ORDER = "admin_order"                     # Admin viewing pending/active order
+    ORDER_DETAIL_ADMIN = "order_detail_admin"       # Admin order history detail
+
+    # User Payment Flow
+    PAYMENT_SCREEN = "payment_screen"               # Initial payment screen with crypto address
+    WALLET_PAYMENT = "wallet_payment"               # Wallet-only payment (no crypto)
+    PAYMENT_SUCCESS = "payment_success"             # Payment completed successfully
+
+    # Order Completion
+    ORDER_SHIPPED = "order_shipped"                 # Physical order shipped notification
+
+    # User Order History
+    ORDER_DETAIL_USER = "order_detail_user"         # User order history detail
+    PURCHASE_HISTORY = "purchase_history"           # Legacy purchase history view
+
+    # Cancellations & Refunds
+    CANCELLATION_REFUND = "cancellation_refund"     # User/timeout cancellation with refund
+    PARTIAL_CANCELLATION = "partial_cancellation"   # Mixed order (digital kept, physical refunded)
+    ADMIN_CANCELLATION = "admin_cancellation"       # Admin-initiated cancellation

--- a/repositories/sales_record.py
+++ b/repositories/sales_record.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,7 +23,7 @@ class SalesRecordRepository:
             ID of created sales record
         """
         sales_record = SalesRecord(
-            sale_date=sales_record_dto.sale_date.date() if sales_record_dto.sale_date else datetime.utcnow().date(),
+            sale_date=sales_record_dto.sale_date.date() if sales_record_dto.sale_date else datetime.now(timezone.utc).date(),
             sale_hour=sales_record_dto.sale_hour,
             sale_weekday=sales_record_dto.sale_weekday,
             category_name=sales_record_dto.category_name,
@@ -63,7 +63,7 @@ class SalesRecordRepository:
         records = []
         for dto in sales_record_dtos:
             record = SalesRecord(
-                sale_date=dto.sale_date.date() if dto.sale_date else datetime.utcnow().date(),
+                sale_date=dto.sale_date.date() if dto.sale_date else datetime.now(timezone.utc).date(),
                 sale_hour=dto.sale_hour,
                 sale_weekday=dto.sale_weekday,
                 category_name=dto.category_name,
@@ -132,7 +132,7 @@ class SalesRecordRepository:
         Returns:
             List of SalesRecord objects
         """
-        cutoff_date = datetime.utcnow().date() - timedelta(days=days)
+        cutoff_date = datetime.now(timezone.utc).date() - timedelta(days=days)
 
         stmt = select(SalesRecord).where(
             SalesRecord.category_name == category_name,
@@ -157,7 +157,7 @@ class SalesRecordRepository:
         Returns:
             Total revenue (sum of item_total_price)
         """
-        cutoff_date = datetime.utcnow().date() - timedelta(days=days)
+        cutoff_date = datetime.now(timezone.utc).date() - timedelta(days=days)
 
         stmt = select(SalesRecord).where(
             SalesRecord.sale_date >= cutoff_date,
@@ -184,7 +184,7 @@ class SalesRecordRepository:
         Returns:
             Total quantity sold
         """
-        cutoff_date = datetime.utcnow().date() - timedelta(days=days)
+        cutoff_date = datetime.now(timezone.utc).date() - timedelta(days=days)
 
         stmt = select(SalesRecord).where(
             SalesRecord.sale_date >= cutoff_date,

--- a/repositories/violation_statistics.py
+++ b/repositories/violation_statistics.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,7 +23,7 @@ class ViolationStatisticsRepository:
             ID of created violation record
         """
         violation = ViolationStatistics(
-            violation_date=violation_dto.violation_date.date() if violation_dto.violation_date else datetime.utcnow().date(),
+            violation_date=violation_dto.violation_date.date() if violation_dto.violation_date else datetime.now(timezone.utc).date(),
             violation_type=violation_dto.violation_type,
             order_value=violation_dto.order_value,
             penalty_applied=violation_dto.penalty_applied if violation_dto.penalty_applied is not None else 0.0,
@@ -75,7 +75,7 @@ class ViolationStatisticsRepository:
         Returns:
             List of ViolationStatistics objects
         """
-        cutoff_date = datetime.utcnow().date() - timedelta(days=days)
+        cutoff_date = datetime.now(timezone.utc).date() - timedelta(days=days)
 
         stmt = select(ViolationStatistics).where(
             ViolationStatistics.violation_type == violation_type,
@@ -120,7 +120,7 @@ class ViolationStatisticsRepository:
         Returns:
             Dictionary mapping violation_type to count
         """
-        cutoff_date = datetime.utcnow().date() - timedelta(days=days)
+        cutoff_date = datetime.now(timezone.utc).date() - timedelta(days=days)
 
         stmt = select(ViolationStatistics).where(
             ViolationStatistics.violation_date >= cutoff_date
@@ -151,7 +151,7 @@ class ViolationStatisticsRepository:
         Returns:
             Total penalty amount
         """
-        cutoff_date = datetime.utcnow().date() - timedelta(days=days)
+        cutoff_date = datetime.now(timezone.utc).date() - timedelta(days=days)
 
         stmt = select(ViolationStatistics).where(
             ViolationStatistics.violation_date >= cutoff_date

--- a/services/analytics.py
+++ b/services/analytics.py
@@ -7,7 +7,7 @@ for long-term analytics while removing user identification (data minimization).
 
 import logging
 import hashlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -79,7 +79,7 @@ class AnalyticsService:
         shipping_type = None
 
         # Current time for temporal data
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # Generate pseudonymized order hash for refund tracking
         # Uses SHA256(order_id + created_at) to enable refund matching without storing actual order_id
@@ -166,7 +166,7 @@ class AnalyticsService:
 
         # Create violation record
         violation_dto = ViolationStatisticsDTO(
-            violation_date=datetime.utcnow(),
+            violation_date=datetime.now(timezone.utc),
             violation_type=violation_type,
             order_value=order.total_price,
             penalty_applied=penalty_applied,
@@ -221,7 +221,7 @@ class AnalyticsService:
         import config
 
         # Calculate date range
-        end_date = datetime.utcnow()
+        end_date = datetime.now(timezone.utc)
         start_date = end_date - timedelta(days=days)
 
         # Get grouped data from repository

--- a/services/buy.py
+++ b/services/buy.py
@@ -78,6 +78,7 @@ class BuyService:
             raise OrderNotFoundException(items[0].order_id if items and items[0].order_id else unpacked_cb.args_for_action)
 
         from services.invoice_formatter import InvoiceFormatterService
+        from enums.invoice_header_type import InvoiceHeaderType
         from services.order import OrderService
         from repositories.subcategory import SubcategoryRepository
 
@@ -126,7 +127,7 @@ class BuyService:
 
         # Use InvoiceFormatter for consistent formatting
         msg = InvoiceFormatterService.format_complete_order_view(
-            header_type="purchase_history",
+            header_type=InvoiceHeaderType.PURCHASE_HISTORY,
             invoice_number=invoice_numbers_formatted,
             order_status=order.status,
             created_at=order.created_at,

--- a/services/cart.py
+++ b/services/cart.py
@@ -300,7 +300,7 @@ class CartService:
         from repositories.invoice import InvoiceRepository
         from repositories.item import ItemRepository
         from repositories.subcategory import SubcategoryRepository
-        from datetime import datetime
+        from datetime import datetime, timezone
         from collections import Counter
         import config
 
@@ -308,7 +308,7 @@ class CartService:
         invoice = await InvoiceRepository.get_by_order_id(order.id, session)
 
         # Calculate timing
-        time_elapsed = (datetime.utcnow() - order.created_at).total_seconds() / 60  # Minutes
+        time_elapsed = (datetime.now(timezone.utc).replace(tzinfo=None) - order.created_at).total_seconds() / 60  # Minutes
         time_remaining = config.ORDER_TIMEOUT_MINUTES - time_elapsed
         can_cancel_free = time_elapsed <= config.ORDER_CANCEL_GRACE_PERIOD_MINUTES
         grace_remaining = config.ORDER_CANCEL_GRACE_PERIOD_MINUTES - time_elapsed
@@ -443,13 +443,13 @@ class CartService:
         Shows "expired" message if order has expired.
         """
         from repositories.invoice import InvoiceRepository
-        from datetime import datetime, timedelta
+        from datetime import datetime, timezone, timedelta
 
         # Get invoice details
         invoice = await InvoiceRepository.get_by_order_id(order.id, session)
 
         # Calculate remaining time
-        time_elapsed = (datetime.utcnow() - order.created_at).total_seconds() / 60  # Minutes
+        time_elapsed = (datetime.now(timezone.utc).replace(tzinfo=None) - order.created_at).total_seconds() / 60  # Minutes
         time_remaining = config.ORDER_TIMEOUT_MINUTES - time_elapsed
         can_cancel_free = time_elapsed <= config.ORDER_CANCEL_GRACE_PERIOD_MINUTES
         is_expired = time_remaining <= 0
@@ -1839,7 +1839,7 @@ class CartService:
 
             # 8. Get invoice and show payment screen
             from repositories.invoice import InvoiceRepository
-            from datetime import datetime
+            from datetime import datetime, timezone
 
             invoice = await InvoiceRepository.get_by_order_id(order.id, session)
 
@@ -1849,7 +1849,7 @@ class CartService:
                 raise ValueError(f"No invoice found for order {order.id}")
 
             # Calculate remaining time for cancel button logic
-            time_elapsed = (datetime.utcnow() - order.created_at).total_seconds() / 60  # Minutes
+            time_elapsed = (datetime.now(timezone.utc).replace(tzinfo=None) - order.created_at).total_seconds() / 60  # Minutes
             can_cancel_free = time_elapsed <= config.ORDER_CANCEL_GRACE_PERIOD_MINUTES
 
             # Format expiry time (HH:MM format)

--- a/services/notification.py
+++ b/services/notification.py
@@ -339,6 +339,7 @@ class NotificationService:
             from repositories.order import OrderRepository
             from repositories.invoice import InvoiceRepository
             from services.invoice_formatter import InvoiceFormatterService
+            from enums.invoice_header_type import InvoiceHeaderType
             from enums.order_status import OrderStatus
 
             # Get order and items
@@ -396,7 +397,7 @@ class NotificationService:
                 subtotal = order.total_price - order.shipping_cost
 
                 msg = InvoiceFormatterService.format_complete_order_view(
-                    header_type="payment_success",
+                    header_type=InvoiceHeaderType.PAYMENT_SUCCESS,
                     invoice_number=invoice_number,
                     order_status=order.status,
                     created_at=order.created_at,
@@ -462,6 +463,7 @@ class NotificationService:
             Formatted message string (does NOT send)
         """
         from services.invoice_formatter import InvoiceFormatterService
+        from enums.invoice_header_type import InvoiceHeaderType
 
         original_amount = refund_info['original_amount']
         penalty_amount = refund_info['penalty_amount']
@@ -519,7 +521,7 @@ class NotificationService:
         if is_mixed_order and partial_refund_details:
             # Mixed order cancellation - show digital items kept, physical items refunded
             return InvoiceFormatterService.format_complete_order_view(
-                header_type="partial_cancellation",
+                header_type=InvoiceHeaderType.PARTIAL_CANCELLATION,
                 invoice_number=invoice_number,
                 items=items_list,
                 shipping_cost=order.shipping_cost,  # Pass shipping cost for display
@@ -537,7 +539,7 @@ class NotificationService:
         elif penalty_amount > 0:
             # Regular cancellation with processing fee and strike - use InvoiceFormatter
             return InvoiceFormatterService.format_complete_order_view(
-                header_type="cancellation_refund",
+                header_type=InvoiceHeaderType.CANCELLATION_REFUND,
                 invoice_number=invoice_number,
                 items=None,  # No items shown for penalty cancellations
                 total_price=refund_info.get('base_amount', 0),
@@ -587,6 +589,7 @@ class NotificationService:
             Formatted message string (does NOT send)
         """
         from services.invoice_formatter import InvoiceFormatterService
+        from enums.invoice_header_type import InvoiceHeaderType
         from utils.localizator import Localizator
         from enums.bot_entity import BotEntity
         import logging
@@ -654,7 +657,7 @@ class NotificationService:
             logging.info(f"🔵 Passing to formatter: cancellation_reason='{escaped_reason}' (from custom_reason='{custom_reason}')")
 
             return InvoiceFormatterService.format_complete_order_view(
-                header_type="admin_cancellation",
+                header_type=InvoiceHeaderType.ADMIN_CANCELLATION,
                 invoice_number=invoice_number,
                 items=items_list,
                 shipping_cost=order.shipping_cost,
@@ -712,6 +715,7 @@ class NotificationService:
         from repositories.item import ItemRepository
         from repositories.subcategory import SubcategoryRepository
         from services.invoice_formatter import InvoiceFormatterService
+        from enums.invoice_header_type import InvoiceHeaderType
 
         user = await UserRepository.get_by_id(user_id, session)
         order = await OrderRepository.get_by_id(order_id, session)
@@ -759,7 +763,7 @@ class NotificationService:
 
         # Format with InvoiceFormatter
         msg = InvoiceFormatterService.format_complete_order_view(
-            header_type="order_shipped",
+            header_type=InvoiceHeaderType.ORDER_SHIPPED,
             invoice_number=invoice_number,
             order_status=order.status,
             created_at=order.created_at,

--- a/services/order_management.py
+++ b/services/order_management.py
@@ -264,6 +264,7 @@ class OrderManagementService:
         """
         from services.shipping import ShippingService
         from services.invoice_formatter import InvoiceFormatterService
+        from enums.invoice_header_type import InvoiceHeaderType
         from exceptions.order import OrderNotFoundException
         from repositories.user import UserRepository
 
@@ -414,7 +415,7 @@ class OrderManagementService:
         should_show_private_data = entity == BotEntity.USER
 
         msg = InvoiceFormatterService.format_complete_order_view(
-            header_type="order_detail_admin" if entity == BotEntity.ADMIN else "order_detail_user",
+            header_type=InvoiceHeaderType.ORDER_DETAIL_ADMIN if entity == BotEntity.ADMIN else "order_detail_user",
             invoice_number=order_data["invoice_number"],
             order_status=order.status,
             created_at=order.created_at,

--- a/tests/analytics/unit/test_analytics_sales_service.py
+++ b/tests/analytics/unit/test_analytics_sales_service.py
@@ -8,7 +8,7 @@ Tests:
 
 import pytest
 import pytest_asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from services.analytics import AnalyticsService
 from repositories.sales_record import SalesRecordRepository
 from models.sales_record import SalesRecordDTO
@@ -131,7 +131,7 @@ async def setup_sales_data(test_session):
     """Create test sales data with multiple subcategories."""
     from models.sales_record import SalesRecordDTO
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     sales = [
         SalesRecordDTO(
@@ -186,7 +186,7 @@ async def setup_sales_data(test_session):
 @pytest_asyncio.fixture
 async def setup_mixed_revenue(test_session):
     """Create sales with varying revenues for sorting test."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     sales = [
         # Low revenue

--- a/tests/analytics/unit/test_sales_record_repository.py
+++ b/tests/analytics/unit/test_sales_record_repository.py
@@ -7,7 +7,7 @@ Tests CRUD operations for anonymized sales records using in-memory SQLite databa
 import pytest
 import sys
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
@@ -49,7 +49,7 @@ class TestSalesRecordRepository:
     async def test_create_many_success(self, session):
         """Test successful creation of multiple SalesRecords."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         dto1 = SalesRecordDTO(
             sale_date=now,
@@ -111,7 +111,7 @@ class TestSalesRecordRepository:
     async def test_get_total_revenue_last_30_days(self, session):
         """Test retrieval of total revenue for last 30 days."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # Create records within 30 days
         dto1 = SalesRecordDTO(
@@ -200,7 +200,7 @@ class TestSalesRecordRepository:
     async def test_get_total_items_sold_last_7_days(self, session):
         """Test retrieval of total items sold for last 7 days."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # Record within 7 days
         dto1 = SalesRecordDTO(
@@ -268,7 +268,7 @@ class TestSalesRecordRepository:
     async def test_get_subcategory_sales_grouped_basic(self, session):
         """Test get_subcategory_sales_grouped with basic data."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         dto1 = SalesRecordDTO(
             sale_date=now,
@@ -333,7 +333,7 @@ class TestSalesRecordRepository:
     async def test_get_subcategory_count(self, session):
         """Test get_subcategory_count."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         dto1 = SalesRecordDTO(
             sale_date=now,
@@ -412,7 +412,7 @@ class TestSalesRecordRepository:
     async def test_get_all_sales_for_csv(self, session):
         """Test get_all_sales_for_csv returns all records."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         dtos = []
         for i in range(10):

--- a/tests/analytics/unit/test_violation_statistics_repository.py
+++ b/tests/analytics/unit/test_violation_statistics_repository.py
@@ -7,7 +7,7 @@ Tests CRUD operations for anonymized violation statistics using in-memory SQLite
 import pytest
 import sys
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
@@ -46,7 +46,7 @@ class TestViolationStatisticsRepository:
     async def test_create_success(self, session):
         """Test successful creation of ViolationStatistics."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         dto = ViolationStatisticsDTO(
             violation_date=now,
@@ -74,7 +74,7 @@ class TestViolationStatisticsRepository:
     async def test_get_by_type(self, session):
         """Test retrieval of violations by type."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # Create late payment violations
         dto1 = ViolationStatisticsDTO(
@@ -131,7 +131,7 @@ class TestViolationStatisticsRepository:
     async def test_get_total_penalties(self, session):
         """Test retrieval of total penalty amount."""
         # Arrange
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         dto1 = ViolationStatisticsDTO(
             violation_date=now - timedelta(days=5),

--- a/tests/notification/test_admin_cancellation_reason.py
+++ b/tests/notification/test_admin_cancellation_reason.py
@@ -20,6 +20,7 @@ import config
 config.DB_ENCRYPTION = False
 
 from services.invoice_formatter import InvoiceFormatterService
+from enums.invoice_header_type import InvoiceHeaderType
 from enums.bot_entity import BotEntity
 
 
@@ -31,7 +32,7 @@ class TestAdminCancellationReason:
         custom_reason = "Artikel nicht mehr auf Lager"
 
         result = InvoiceFormatterService.format_complete_order_view(
-            header_type="admin_cancellation",
+            header_type=InvoiceHeaderType.ADMIN_CANCELLATION,
             invoice_number="INV-2025-000123",
             items=[
                 {
@@ -57,7 +58,7 @@ class TestAdminCancellationReason:
     def test_admin_cancellation_without_custom_reason(self):
         """Test that message works without custom reason (None)"""
         result = InvoiceFormatterService.format_complete_order_view(
-            header_type="admin_cancellation",
+            header_type=InvoiceHeaderType.ADMIN_CANCELLATION,
             invoice_number="INV-2025-000124",
             items=[
                 {
@@ -87,7 +88,7 @@ class TestAdminCancellationReason:
 
         # Pass raw string - formatter should escape it
         result = InvoiceFormatterService.format_complete_order_view(
-            header_type="admin_cancellation",
+            header_type=InvoiceHeaderType.ADMIN_CANCELLATION,
             invoice_number="INV-2025-000125",
             items=[
                 {
@@ -114,7 +115,7 @@ class TestAdminCancellationReason:
         multiline_reason = "Artikel nicht verfügbar\nLieferant hat storniert\nKunde wird kontaktiert"
 
         result = InvoiceFormatterService.format_complete_order_view(
-            header_type="admin_cancellation",
+            header_type=InvoiceHeaderType.ADMIN_CANCELLATION,
             invoice_number="INV-2025-000126",
             items=[
                 {

--- a/tests/payment/unit/test_invoice_lifecycle.py
+++ b/tests/payment/unit/test_invoice_lifecycle.py
@@ -13,7 +13,7 @@ Run with:
 import pytest
 import sys
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch, MagicMock
 
@@ -161,8 +161,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=30)
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30)
         )
         session.add(order)
         session.commit()
@@ -191,8 +191,8 @@ class TestInvoiceLifecycle:
         assert invoice.payment_crypto_currency == Cryptocurrency.BTC
 
         # Verify order
-        assert order.expires_at > datetime.utcnow()
-        assert (order.expires_at - datetime.utcnow()).total_seconds() <= 1800  # 30 minutes
+        assert order.expires_at > datetime.now(timezone.utc).replace(tzinfo=None)
+        assert (order.expires_at - datetime.now(timezone.utc).replace(tzinfo=None)).total_seconds() <= 1800  # 30 minutes
 
     # ==================== Scenario 2: Wallet-Only Payment ====================
 
@@ -218,8 +218,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=30)
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30)
         )
         session.add(order)
         session.commit()
@@ -279,8 +279,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=30)
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30)
         )
         session.add(order)
         session.commit()
@@ -336,8 +336,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=30)
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30)
         )
         session.add(order)
         session.commit()
@@ -359,7 +359,7 @@ class TestInvoiceLifecycle:
         # Simulate payment webhook (would be called by webhook handler)
         # For this test, we manually update order status and mark items sold
         order.status = OrderStatus.PAID
-        order.paid_at = datetime.utcnow()
+        order.paid_at = datetime.now(timezone.utc)
         for item in test_items:
             item.is_sold = True
         session.commit()
@@ -375,7 +375,7 @@ class TestInvoiceLifecycle:
             fiat_currency=Currency.EUR,
             payment_address="bc1qmock123test456",
             transaction_hash="mock_tx_hash",
-            received_at=datetime.utcnow(),
+            received_at=datetime.now(timezone.utc),
             is_underpayment=False,
             is_overpayment=False,
             is_late_payment=False,
@@ -424,8 +424,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow() - timedelta(minutes=45),
-            expires_at=datetime.utcnow() - timedelta(minutes=15)  # Expired 15 min ago
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=45),
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=15)  # Expired 15 min ago
         )
         session.add(order)
         session.commit()
@@ -497,8 +497,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=10.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow(),  # Just created
-            expires_at=datetime.utcnow() + timedelta(minutes=30)
+            created_at=datetime.now(timezone.utc),  # Just created
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30)
         )
         session.add(order)
         # Deduct wallet (as would happen in real order creation)
@@ -562,8 +562,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=10.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow() - timedelta(minutes=10),  # Outside grace period
-            expires_at=datetime.utcnow() + timedelta(minutes=20)
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=10),  # Outside grace period
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=20)
         )
         session.add(order)
         # Deduct wallet (as would happen in real order creation)
@@ -633,8 +633,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=10.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow() - timedelta(minutes=10),
-            expires_at=datetime.utcnow() + timedelta(minutes=20)
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=20)
         )
         session.add(order)
         # Deduct wallet (as would happen in real order creation)
@@ -707,8 +707,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=30)
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30)
         )
         session.add(order)
         session.commit()
@@ -750,7 +750,7 @@ class TestInvoiceLifecycle:
             fiat_currency=Currency.EUR,
             payment_address="bc1qmock123test456",
             transaction_hash="mock_tx_hash",
-            received_at=datetime.utcnow(),
+            received_at=datetime.now(timezone.utc),
             is_underpayment=True,
             is_overpayment=False,
             is_late_payment=False,
@@ -804,8 +804,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow() - timedelta(minutes=45),
-            expires_at=datetime.utcnow() - timedelta(minutes=5)  # Expired 5 min ago
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=45),
+            expires_at=datetime.now(timezone.utc) - timedelta(minutes=5)  # Expired 5 min ago
         )
         session.add(order)
         session.commit()
@@ -826,7 +826,7 @@ class TestInvoiceLifecycle:
 
         # Simulate late payment (payment arrives before timeout job runs)
         order.status = OrderStatus.PAID
-        order.paid_at = datetime.utcnow()
+        order.paid_at = datetime.now(timezone.utc)
         for item in test_items:
             item.is_sold = True
         session.commit()
@@ -842,7 +842,7 @@ class TestInvoiceLifecycle:
             fiat_currency=Currency.EUR,
             payment_address="bc1qmock123test456",
             transaction_hash="mock_tx_hash",
-            received_at=datetime.utcnow(),
+            received_at=datetime.now(timezone.utc),
             is_underpayment=False,
             is_overpayment=False,
             is_late_payment=True,  # Payment was late
@@ -893,8 +893,8 @@ class TestInvoiceLifecycle:
                 total_price=30.0,
                 wallet_used=0.0,
                 status=status,
-                created_at=datetime.utcnow() - timedelta(hours=1),
-                expires_at=datetime.utcnow() - timedelta(minutes=30)
+                created_at=datetime.now(timezone.utc) - timedelta(hours=1),
+                expires_at=datetime.now(timezone.utc) - timedelta(minutes=30)
             )
             session.add(order)
         session.commit()
@@ -936,8 +936,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=30)
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30)
         )
         session.add(order)
         session.commit()
@@ -978,8 +978,8 @@ class TestInvoiceLifecycle:
             total_price=30.0,
             wallet_used=0.0,
             status=OrderStatus.PENDING_PAYMENT,
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(minutes=30)
+            created_at=datetime.now(timezone.utc),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30)
         )
         session.add(order)
         session.commit()


### PR DESCRIPTION
Replaces 11 magic strings with InvoiceHeaderType enum and migrates from deprecated datetime.utcnow() to datetime.now(timezone.utc). Backward compatible during migration.