### PR TITLE
fix: router registration broke button handlers

### DIFF
--- a/run.py
+++ b/run.py
@@ -147,7 +147,7 @@ users_routers.message.middleware(throttling_middleware)
 users_routers.callback_query.middleware(throttling_middleware)
 main_router.include_router(admin_router)
 main_router.include_router(shipping_management_router)
-main_router.include_routers(users_routers)
+main_router.include_router(users_routers)
 main_router.message.middleware(DBSessionMiddleware())
 main_router.callback_query.middleware(DBSessionMiddleware())
 


### PR DESCRIPTION
Fixed router registration by changing include_routers() to include_router() on line 150.
This bug prevented All Categories, My Profile, and Cart button handlers from registering after PR #76.