### PR TITLE
security: fix PII logging and multi-language bug in ButtonTextFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## 2025-12-01
 
+### Security Fixes
+
+**Button Filter PII Logging Vulnerability**
+- Removed logging of user message text in ButtonTextFilter to prevent exposure of sensitive data (shipping addresses, payment info)
+- Fixed multi-language button matching: now checks user's Telegram language setting first before falling back to config default
+- Button handlers now work correctly for all users regardless of their Telegram client language
+
 ### Bug Fixes
 
 **Main Menu Button Handler Registration**


### PR DESCRIPTION
## Summary
- Fix PII logging vulnerability in ButtonTextFilter (prevents logging of addresses, payment info, etc.)
- Fix multi-language bug: buttons now work for all users regardless of Telegram language setting
- Remove unused import_config() helper function

## Changes
- **Security**: Remove message.text from warning logs to prevent PII exposure
- **Functionality**: Check user's Telegram language first (matches /start behavior), then fallback to config.BOT_LANGUAGE
- **Cleanup**: Remove unused import_config() helper

## Testing
- [x] Code review
- [ ] Manual testing with different Telegram languages
- [ ] Verify no PII in logs

## Related Issues
Addresses critical issues found in Codex review of fix/router-registration-bug