### PR TITLE
Add webhook/polling mode toggle for flexible deployment

### DIFF
--- a/.env.dev.template
+++ b/.env.dev.template
@@ -26,6 +26,17 @@
 # Example: 1234567890:ABCdefGHIjklMNOpqrsTUVwxyz1234567890
 TOKEN=
 
+# Webhook Mode Configuration
+# - "webhook": Telegram pushes updates to your server (requires public HTTPS endpoint, faster response)
+# - "polling": Bot polls Telegram API for updates (no public endpoint needed, VPN-friendly, ~1s delay)
+# Default: webhook (recommended for development with ngrok)
+WEBHOOK_MODE=webhook
+
+# Polling timeout in seconds (1-50, only used if WEBHOOK_MODE=polling)
+# Lower value = faster response but more API calls. Recommended: 10
+# Only relevant when WEBHOOK_MODE=polling
+POLLING_TIMEOUT=10
+
 # Comma-separated list of Telegram user IDs with admin privileges
 # Find your ID via @userinfobot
 # Example: 123456789

--- a/.env.prod.template
+++ b/.env.prod.template
@@ -29,6 +29,18 @@
 # Example: 1234567890:ABCdefGHIjklMNOpqrsTUVwxyz1234567890
 TOKEN=
 
+# Webhook Mode Configuration
+# - "webhook": Telegram pushes updates to your server (requires public HTTPS endpoint, faster response)
+# - "polling": Bot polls Telegram API for updates (no public endpoint needed, VPN-friendly, ~1s delay)
+# Default: webhook (recommended for production with proper SSL/TLS setup)
+# Use "polling" if running through VPN without public port forwarding
+WEBHOOK_MODE=webhook
+
+# Polling timeout in seconds (1-50, only used if WEBHOOK_MODE=polling)
+# Lower value = faster response but more API calls. Recommended: 10
+# Only relevant when WEBHOOK_MODE=polling
+POLLING_TIMEOUT=10
+
 # Comma-separated list of Telegram user IDs with admin privileges
 # Find your ID via @userinfobot
 # Example: 123456789,987654321

--- a/bot.py
+++ b/bot.py
@@ -11,11 +11,16 @@ import config
 from utils.config_validator import validate_or_exit
 validate_or_exit(config)
 
-# Initialize webhook configuration (must happen before app setup)
+# Initialize webhook configuration (only if webhook mode)
 # This performs side effects (ngrok start, HTTP request) that were previously
 # happening at module import time, which violated "import should be safe" principle
-config.initialize_webhook_config()
-logging.info(f"[Init] Webhook configuration initialized: {config.WEBHOOK_URL}")
+from enums.webhook_mode import WebhookMode
+
+if config.WEBHOOK_MODE == WebhookMode.WEBHOOK:
+    config.initialize_webhook_config()
+    logging.info(f"[Init] Webhook configuration initialized: {config.WEBHOOK_URL}")
+else:
+    logging.info(f"[Init] Bot running in POLLING mode (no webhook)")
 
 # Load shipping types configuration for selected country
 from utils.shipping_types_loader import load_shipping_types
@@ -79,11 +84,18 @@ async def lifespan(app: FastAPI):
 
     # Startup
     await create_db_and_tables()
-    await bot.set_webhook(
-        url=config.WEBHOOK_URL,
-        secret_token=config.WEBHOOK_SECRET_TOKEN
-    )
-    logging.info(f"[Startup] Webhook registered with Telegram")
+
+    # Only set webhook if in webhook mode
+    if config.WEBHOOK_MODE == WebhookMode.WEBHOOK:
+        await bot.set_webhook(
+            url=config.WEBHOOK_URL,
+            secret_token=config.WEBHOOK_SECRET_TOKEN
+        )
+        logging.info(f"[Startup] Webhook registered with Telegram")
+    else:
+        # Ensure webhook is deleted in polling mode
+        await bot.delete_webhook(drop_pending_updates=True)
+        logging.info(f"[Startup] Webhook deleted (polling mode)")
 
     # Start payment timeout job
     await payment_timeout_job.start()
@@ -223,4 +235,76 @@ async def exception_handler(request: Request, exc: Exception):
 
 
 def main() -> None:
-    uvicorn.run(app, host=config.WEBAPP_HOST, port=config.WEBAPP_PORT)
+    """
+    Start the bot in either webhook or polling mode based on configuration.
+    """
+    if config.WEBHOOK_MODE == WebhookMode.WEBHOOK:
+        # Webhook mode: Start uvicorn server
+        uvicorn.run(app, host=config.WEBAPP_HOST, port=config.WEBAPP_PORT)
+    else:
+        # Polling mode: Start polling
+        asyncio.run(main_polling())
+
+
+async def main_polling() -> None:
+    """
+    Start bot in polling mode.
+    Runs startup tasks then starts polling for updates.
+    """
+    global backup_task, data_retention_task
+
+    # Startup tasks
+    await create_db_and_tables()
+    await bot.delete_webhook(drop_pending_updates=True)
+    logging.info(f"[Startup] Webhook deleted (polling mode)")
+
+    # Start payment timeout job
+    await payment_timeout_job.start()
+
+    # Start database backup scheduler (if enabled)
+    if config.DB_BACKUP_ENABLED:
+        backup_task = asyncio.create_task(backup_scheduler())
+        logging.info("[Startup] Database backup scheduler started")
+    else:
+        logging.info("[Startup] Database backup scheduler disabled")
+
+    # Start data retention cleanup job
+    data_retention_task = asyncio.create_task(start_data_retention_cleanup_job())
+    logging.info("[Startup] Data retention cleanup job started")
+
+    # Notify admins on startup
+    for admin in config.ADMIN_ID_LIST:
+        try:
+            await bot.send_message(admin, 'Bot is working (polling mode)')
+        except Exception as e:
+            logging.warning(e)
+
+    # Start polling
+    logging.info(f"[Startup] Starting polling with timeout={config.POLLING_TIMEOUT}s...")
+    try:
+        await dp.start_polling(
+            bot,
+            polling_timeout=config.POLLING_TIMEOUT,
+            allowed_updates=dp.resolve_used_update_types()
+        )
+    finally:
+        # Shutdown tasks
+        logging.warning('Shutting down..')
+        await payment_timeout_job.stop()
+
+        if backup_task is not None:
+            backup_task.cancel()
+            try:
+                await backup_task
+            except asyncio.CancelledError:
+                logging.info("[Shutdown] Database backup scheduler stopped")
+
+        if data_retention_task is not None:
+            data_retention_task.cancel()
+            try:
+                await data_retention_task
+            except asyncio.CancelledError:
+                logging.info("[Shutdown] Data retention cleanup job stopped")
+
+        await dp.storage.close()
+        logging.warning('Bye!')

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 
 from enums.currency import Currency
 from enums.runtime_environment import RuntimeEnvironment
+from enums.webhook_mode import WebhookMode
 from external_ip import get_sslipio_external_url
 from ngrok_executor import start_ngrok
 
@@ -256,3 +257,20 @@ WEBHOOK_SECURITY_HEADERS_ENABLED = os.environ.get("WEBHOOK_SECURITY_HEADERS_ENAB
 WEBHOOK_CSP_ENABLED = os.environ.get("WEBHOOK_CSP_ENABLED", "false") == "true"  # Enable Content Security Policy
 WEBHOOK_HSTS_ENABLED = os.environ.get("WEBHOOK_HSTS_ENABLED", "false") == "true"  # Enable HSTS (only for HTTPS)
 WEBHOOK_CORS_ALLOWED_ORIGINS = os.environ.get("WEBHOOK_CORS_ALLOWED_ORIGINS", "").split(",") if os.environ.get("WEBHOOK_CORS_ALLOWED_ORIGINS") else []  # CORS allowed origins
+
+# Webhook Mode Configuration
+try:
+    _webhook_mode_str = os.environ.get("WEBHOOK_MODE", "webhook")
+    WEBHOOK_MODE = WebhookMode(_webhook_mode_str)
+except ValueError as e:
+    valid_modes = [mode.value for mode in WebhookMode]
+    import sys
+    print(f"\n ERROR: Invalid WEBHOOK_MODE configuration\n", file=sys.stderr)
+    print(f"Reason: {e}", file=sys.stderr)
+    print(f"Valid values: {', '.join(valid_modes)}", file=sys.stderr)
+    print(f"Current value: {os.environ.get('WEBHOOK_MODE', '(not set)')}", file=sys.stderr)
+    print(f"\nAdd to .env: WEBHOOK_MODE={valid_modes[0]}\n", file=sys.stderr)
+    sys.exit(1)
+
+# Polling timeout configuration (only used when WEBHOOK_MODE=polling)
+POLLING_TIMEOUT = int(os.environ.get("POLLING_TIMEOUT", "10"))  # Default: 10 seconds

--- a/enums/webhook_mode.py
+++ b/enums/webhook_mode.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class WebhookMode(Enum):
+    """
+    Webhook mode configuration for bot operation.
+
+    WEBHOOK: Telegram pushes updates to bot (requires public HTTPS endpoint)
+    POLLING: Bot polls Telegram API for updates (no public endpoint needed)
+    """
+    WEBHOOK = "webhook"
+    POLLING = "polling"

--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,8 @@ After copying the appropriate template, fill in all empty values and customize a
 | REDIS_PASSWORD            | Required variable, needed to make the throttling mechanism work.                                                                                                                                                                                                                                                            | Any string you want                                                 |
 | REDIS_HOST                | Required variable, needed to make the throttling mechanism work.                                                                                                                                                                                                                                                            | "redis" for docker-compose.yml                                      |
 | BOT_DOMAIN                | Domain for Telegram Mini App (PGP encryption feature). HTTPS required. Supports auto-configuration: leave empty in development (auto-set from ngrok URL), set explicitly in production (your domain or external IP). See "BOT_DOMAIN Auto-Configuration" section below for details.                                          | Empty (dev) or "bot.yourdomain.com" (prod)                          |
+| WEBHOOK_MODE              | Determines how the bot receives updates from Telegram. "webhook" requires public HTTPS endpoint (ports 80/88/443/8443), "polling" requires no public endpoint. See "Webhook Mode and Polling Mode" section below for details.                                                                                               | "webhook" (default) or "polling"                                    |
+| POLLING_TIMEOUT           | Timeout in seconds for polling updates from Telegram (1-50). Only used when WEBHOOK_MODE=polling. Lower value = faster response but more API calls. See "Webhook Mode and Polling Mode" section below.                                                                                                                      | 10 (only relevant for polling mode)                                 |
 
 #### BOT_DOMAIN Auto-Configuration
 
@@ -149,6 +151,51 @@ The `BOT_DOMAIN` variable is used for the PGP-encrypted shipping address feature
   - Requires valid SSL certificate for the domain
 
 Auto-configuration ensures the Mini App works immediately without manual URL configuration, while still allowing explicit configuration for production environments with custom domains.
+
+#### Webhook Mode and Polling Mode
+
+The bot supports two modes for receiving Telegram updates, configurable via the `WEBHOOK_MODE` environment variable:
+
+**Webhook Mode (Default)**:
+- Telegram pushes updates to your bot via HTTPS webhook
+- Requires public HTTPS endpoint on ports: 80, 88, 443, or 8443
+- Faster response time (instant delivery)
+- Recommended for standard production deployments
+
+**Polling Mode**:
+- Bot polls Telegram API for updates via `getUpdates`
+- No public endpoint required
+- Slight delay in receiving updates (configurable, default ~1 second)
+- Useful for environments where exposing public ports is not feasible
+
+**Configuration:**
+
+Set `WEBHOOK_MODE` in your `.env` file:
+```bash
+# Webhook mode (default, requires public HTTPS)
+WEBHOOK_MODE=webhook
+
+# Polling mode (no public endpoint needed)
+WEBHOOK_MODE=polling
+
+# Polling timeout in seconds (only used when WEBHOOK_MODE=polling)
+# Lower value = faster response but more API calls. Default: 10
+POLLING_TIMEOUT=10
+```
+
+**When to Use Each Mode:**
+
+Use **Webhook Mode** when:
+- You have a public server with HTTPS
+- You can expose ports 80, 88, 443, or 8443
+- You want instant update delivery
+
+Use **Polling Mode** when:
+- You cannot expose public webhook ports
+- You don't have a public HTTPS endpoint
+- You prefer simpler network setup without reverse proxy
+
+Both modes support all bot features (background jobs, database operations, admin functions). The only difference is how updates are received from Telegram.
 
 ### 1.1 Starting AiogramShopBot with Docker-compose
 


### PR DESCRIPTION
## Summary

Adds configurable webhook/polling mode toggle to support flexible deployment scenarios.

### Changes

**New Feature: WEBHOOK_MODE Configuration**
- WebhookMode enum with WEBHOOK and POLLING values
- config.py parsing with validation and error handling
- Conditional webhook initialization (only when WEBHOOK_MODE=webhook)
- New main_polling() function for polling mode operation
- POLLING_TIMEOUT configuration (1-50 seconds, default: 10)

**Bot Behavior**
- Webhook mode: FastAPI/Uvicorn server receives Telegram webhook requests
- Polling mode: Aiogram polling loop fetches updates via getUpdates API
- Both modes support all bot features (jobs, database, admin functions)

**Configuration**
- .env.dev.template: WEBHOOK_MODE and POLLING_TIMEOUT added with detailed comments
- .env.prod.template: WEBHOOK_MODE and POLLING_TIMEOUT added with detailed comments
- Default: webhook mode (backward compatible)

**Documentation**
- README.md: New "Webhook Mode and Polling Mode" section
- Environment variables table updated with WEBHOOK_MODE and POLLING_TIMEOUT
- Usage guidance for when to use each mode

### Test Plan

- [x] Webhook mode tested (default behavior unchanged)
- [x] Polling mode tested (successful update reception)
- [x] Config validation tested (invalid WEBHOOK_MODE rejected)
- [x] Documentation reviewed

### Technical Details

**Files Changed:**
- `enums/webhook_mode.py` (NEW): WebhookMode enum
- `config.py`: WEBHOOK_MODE parsing, conditional webhook initialization
- `bot.py`: main_polling() function, conditional webhook setup in lifespan
- `.env.dev.template`: WEBHOOK_MODE and POLLING_TIMEOUT config
- `.env.prod.template`: WEBHOOK_MODE and POLLING_TIMEOUT config
- `readme.md`: Documentation for both modes

**Backward Compatibility:**
- Default WEBHOOK_MODE=webhook maintains existing behavior
- No breaking changes to existing deployments